### PR TITLE
Make gen_server terminate properly

### DIFF
--- a/src/leo_mq_sup.erl
+++ b/src/leo_mq_sup.erl
@@ -104,8 +104,12 @@ after_proc(Error) ->
 %% @private
 close_db([]) ->
     ok;
+close_db([{Id,_Pid, worker, ['leo_mq_consumer'|_]}|T]) ->
+    supervisor:terminate_child(?MODULE, Id),
+    close_db(T);
 close_db([{Id,_Pid, worker, ['leo_mq_server' = Mod|_]}|T]) ->
     ok = Mod:close(Id),
+    supervisor:terminate_child(?MODULE, Id),
     close_db(T);
 close_db([_|T]) ->
     close_db(T).


### PR DESCRIPTION
Part of fix for https://github.com/leo-project/leofs/issues/960.
After applying this PR, some error lines still can be remained like below. (however the error log get much cleaner than the one without PR)
```erlang
[E]     storage_0@127.0.0.1     2017-12-28 16:16:35.511796 +0900        1514445395      null:null       0       Error in process <0.3854.0> on node 'storage_0@127.0.0.1' with exit value:
{badarg,[{gen_fsm,send_event,2,[{file,"gen_fsm.erl"},{line,215}]}]}
```
Those errors should be stripped by fixes on leo_storage. 