### PR TITLE
Fix for #971

### DIFF
--- a/src/leo_mq_server.erl
+++ b/src/leo_mq_server.erl
@@ -366,14 +366,10 @@ handle_info(_Info, State) ->
 %% <p>
 %% gen_server callback - Module:terminate(Reason, State)
 %% </p>
-terminate(_Reason, #state{id = Id,
-                          mq_properties = MQProps}) ->
+terminate(_Reason, #state{id = Id}) ->
     error_logger:info_msg("~p,~p,~p,~p~n",
                           [{module, ?MODULE_STRING}, {function, "terminate/1"},
                            {line, ?LINE}, {body, Id}]),
-    %% Close the backend_db
-    MQDBMessageId = MQProps#mq_properties.mqdb_id,
-    ok = close_db(MQDBMessageId),
     ok.
 
 


### PR DESCRIPTION
https://github.com/leo-project/leofs/issues/971 happened due to unnecessary closing the leo_backend_db instance in case of gen_server terminated by an unexpected error. leo_backend_db instance should be closed only in case of normal termination (leo_storage stop)