### PR TITLE
Use leo_backend_db_server:first_n/2 to reduce CPU usage for #994

### DIFF
--- a/src/leo_mq_server.erl
+++ b/src/leo_mq_server.erl
@@ -264,10 +264,7 @@ handle_call(peek, _From, #state{backend_db_id = BackendDbId} = State) ->
     {reply, Reply, State};
 
 handle_call({peek, N}, _From, #state{backend_db_id = BackendDbId} = State) ->
-    Condition = fun(_K,_V) ->
-                        true
-                end,
-    Reply = case catch leo_backend_db_server:first_n(BackendDbId, N, Condition) of
+    Reply = case catch leo_backend_db_server:first_n(BackendDbId, N) of
                 {ok, List0} ->
                     Fun = fun({Key, Val}) ->
                                   %% Taking measure of queue-msg migration


### PR DESCRIPTION
This is the last PR for #994  and #710. Once this PR get merged, I'm going to benchmark on RIT evn to measure how much CPU usage this feature can reduce.